### PR TITLE
fix(security): resolve CodeQL regex alerts and pin fixture base images

### DIFF
--- a/grype/match/explicit_ignores.go
+++ b/grype/match/explicit_ignores.go
@@ -25,7 +25,7 @@ func init() {
 		{
 			typ:             "go-module",
 			vulnerabilities: []string{"CVE-2015-5237", "CVE-2021-22570"},
-			packages:        []string{"google.golang.org/protobuf"},
+			packages:        []string{`google\.golang\.org/protobuf`},
 		},
 		// Affects Squiz Matrix, not in any way related to the matrix ruby gem
 		{

--- a/test/integration/test-fixtures/image-alpine-match-coverage/Dockerfile
+++ b/test/integration/test-fixtures/image-alpine-match-coverage/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/go@sha256:a4f6cf8c738e90644da3e43cee29865ea8968399e79f696d4bc162a1c4379739@sha256:a4f6cf8c738e90644da3e43cee29865ea8968399e79f696d4bc162a1c4379739 AS builder
+FROM cgr.dev/chainguard/go:latest@sha256:fa81487f6395a6fd69d9b4f424683f1f690b9ab55cf2603ed597b0415beafdb9 as builder
 
 RUN go install github.com/google/ko@v0.15.1
 


### PR DESCRIPTION
Fixes the code-fixable open code-scanning alerts:

- **Alerts #10, #11 (CodeQL)** — `grype/match/explicit_ignores.go`: the explicit-ignore package name `google.golang.org/protobuf` is compiled into a regex by `packageNameRegex`; unescaped dots could match unintended package names. Dots are now escaped. `go test ./grype/match/` passes.
- **Alerts #2, #3 (Scorecard PinnedDependencies)** — pinned base images by sha256 digest in the alpine and rust-auditable integration test-fixture Dockerfiles.

Not addressed here (not fixable in code): Scorecard repo-level alerts #4–#9, #13 (Maintained, BranchProtection, CodeReview, CIIBestPractices, Fuzzing, SAST, Vulnerabilities) and #1 (BinaryArtifacts — a jar that is itself a test fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)